### PR TITLE
Add GraphQL endpoint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -39,7 +39,9 @@
     "@effection/node": "^0.6.5",
     "@octokit/webhooks": "^7.6.4",
     "effection": "^0.7.0",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "express-graphql": "^0.10.2",
+    "graphql": "^14.7.0"
   },
   "volta": {
     "node": "12.11.1",

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -2,7 +2,7 @@ import { Channel } from '@effection/channel';
 
 import { espresso } from './espresso';
 import { createWebhookHandler, WebhookEvent } from './github-webhooks';
-export { WebhookEvent } from './github-webhooks';
+import { createGraphqQLHandler } from './graphql';
 
 export interface APIOptions {
   githubWebhookSecret: string;
@@ -10,5 +10,8 @@ export interface APIOptions {
 }
 export function createAPI(options: APIOptions)  {
   return espresso()
-    .use('/github-webhook', createWebhookHandler(options.githubWebhookSecret, options.webhooks));
+    .use('/github-webhook', createWebhookHandler(options.githubWebhookSecret, options.webhooks))
+    .use('/graphql', createGraphqQLHandler());
 }
+
+export { WebhookEvent } from './github-webhooks';

--- a/backend/src/espresso.ts
+++ b/backend/src/espresso.ts
@@ -26,7 +26,7 @@ export class Espresso {
     let app = express();
     let handlers: Operation<void>[] = [];
     for (let route of this.routes) {
-      let channel = new Channel<[express.Request, express.Response, express.NextFunction]>();
+      let channel = new Channel<[express.Request, express.Response, express.NextFunction], void>();
       handlers.push(route.handler(channel))
       app[route.method](route.path, (request, response, next) => {
         channel.send([request, response, next]);
@@ -63,7 +63,9 @@ export interface Route {
 }
 
 export interface RequestHandler {
-  (channel: Channel<[express.Request, express.Response, express.NextFunction]>): Operation<void>;
+  (channel: Channel<Intercept, void>): Operation<void>;
 }
+
+export type Intercept = [express.Request, express.Response, express.NextFunction];
 
 export type RouteMatchType = 'get' | 'post' | 'use';

--- a/backend/src/github-webhooks.ts
+++ b/backend/src/github-webhooks.ts
@@ -3,8 +3,7 @@ import { Channel } from '@effection/channel';
 import { forEach } from '@effection/subscription';
 import { Webhooks } from '@octokit/webhooks';
 
-import { Request, Response, NextFunction } from 'express';
-import { RequestHandler } from './espresso';
+import { RequestHandler, Intercept } from './espresso';
 
 export type WebhookEvent<T = unknown> = Webhooks.WebhookEvent<T>;
 
@@ -14,7 +13,7 @@ export function createWebhookHandler(secret: string, events: Channel<WebhookEven
 
   webhooks.on('*', event => events.send(event));
 
-  return (requests: Channel<[Request, Response, NextFunction]>) => forEach(requests, function*([request, response, next]) {
+  return (requests: Channel<Intercept, void>) => forEach(requests, function*([request, response, next]) {
     webhooks.middleware(request, response, next);
   }) as Operation<void>;
 }

--- a/backend/src/graphql.ts
+++ b/backend/src/graphql.ts
@@ -1,0 +1,21 @@
+import { Channel } from '@effection/channel';
+import { forEach } from '@effection/subscription';
+import { schema } from './schema';
+import { graphqlHTTP } from 'express-graphql';
+import { buildSchema } from 'graphql';
+import { Operation } from 'effection';
+import { Intercept } from './espresso';
+
+export function createGraphqQLHandler() {
+  let middleware = graphqlHTTP({
+    schema: buildSchema(schema),
+    rootValue: {
+      echo: ({ message }: { message: string}) => message
+    },
+    graphiql: true
+  });
+
+  return (channel: Channel<Intercept, void>) => forEach(channel, function*([request, response]) {
+    middleware(request, response);
+  }) as Operation<void>;
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,7 +7,9 @@ import { Orchestrator, createOrchestrator } from './orchestrator';
 
 main(function*() {
   let server: Orchestrator = yield createOrchestrator(env);
-  console.log(`--> listening on port ${server.address.port}`);
+  console.log(`--> server listening on port ${server.address.port}`);
+  console.log(`  * graphql: http://localhost:${server.address.port}/graphql`);
+  console.log(`  * webhook: http://localhost:${server.address.port}/github-webhooks`);
 
   yield spawn(forEach(server.webhooks, function*(event) {
     let { id, name, } = event;

--- a/backend/src/schema.ts
+++ b/backend/src/schema.ts
@@ -1,0 +1,5 @@
+export const schema = `
+type Query {
+  echo(message: String!): String
+}
+`

--- a/backend/test/graphql.test.ts
+++ b/backend/test/graphql.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from 'mocha';
+import * as expect from 'expect';
+import { ExecutionResult } from 'graphql';
+
+import { createTestServer } from './helpers';
+import { TestServer } from './helpers/test-server';
+
+describe('graphql', () => {
+  let server: TestServer;
+
+  beforeEach(async () => {
+    server = await createTestServer();
+  });
+
+  describe('query over http', () => {
+    let result: ExecutionResult;
+    beforeEach(async () => {
+      result = await server.query(`{ echo(message: "Hello World") }`);
+    });
+
+    it('successfully executes the query', () => {
+      expect(result).toEqual({ data: { echo: "Hello World"} });
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3408,6 +3408,16 @@ expect@^26.1.0:
     jest-message-util "^26.1.0"
     jest-regex-util "^26.0.0"
 
+express-graphql@^0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/express-graphql/-/express-graphql-0.10.2.tgz#1b83a9f2a07cb04e59b34fd0396bba81a2c67121"
+  integrity sha512-OV8L1li3e2kFegslfyxY/Geh0JCRy/pmZUQmiRP+B3LUuRq4w8D+esjZodhW4vh8N0SeA5fFZ1UvbnVkt/fGOw==
+  dependencies:
+    accepts "^1.3.7"
+    content-type "^1.0.4"
+    http-errors "1.8.0"
+    raw-body "^2.4.1"
+
 express-graphql@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/express-graphql/-/express-graphql-0.9.0.tgz#00fd8552f866bac5c9a4612b2c4c82076107b3c2"
@@ -3940,6 +3950,13 @@ graphql@^14.5.8:
   dependencies:
     iterall "^1.2.2"
 
+graphql@^14.7.0:
+  version "14.7.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
+  integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
+  dependencies:
+    iterall "^1.2.2"
+
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
@@ -4155,6 +4172,17 @@ http-errors@1.7.3, http-errors@^1.7.3, http-errors@~1.7.2:
     depd "~1.1.2"
     inherits "2.0.4"
     setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
+http-errors@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.8.0.tgz#75d1bbe497e1044f51e4ee9e704a62f28d336507"
+  integrity sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.2.0"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
@@ -6839,6 +6867,11 @@ setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
   integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
+
+setprototypeof@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
+  integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
 sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.11"


### PR DESCRIPTION
The primary mode for reading and writing state to the release app will be via GraphQL.

This adds a simple graphql endpoint just to set up the basic infrastructure.